### PR TITLE
Add missing dependencies to xmr-crypto-utils

### DIFF
--- a/packages/xmr-crypto-utils/package.json
+++ b/packages/xmr-crypto-utils/package.json
@@ -39,6 +39,8 @@
 		"@xmr-core/xmr-str-utils": "^0.0.8",
 		"@xmr-core/xmr-varint": "^0.0.8",
 		"@xmr-core/xmr-vendor": "^0.0.8",
+		"@xmr-core/xmr-b58": "^0.0.8",
+		"@xmr-core/xmr-constants": "^0.0.8",
 		"node-hid": "^0.7.3",
 		"u2f-api": "^1.0.6"
 	},


### PR DESCRIPTION
These two dependencies are used in [this file](https://github.com/MyCryptoHQ/xmr-core/blob/develop/packages/xmr-crypto-utils/src/address-utils/utils.ts) which causes the `xmr-crypto-utils` to throw an error if we try to install `@xmr-core/xmr-crypto-utils` with yarn and use it.